### PR TITLE
[fix] 탈퇴 후 재로그인 시에 나오는 여러 데이터 캐시 문제들 (#99)

### DIFF
--- a/app/delete_account.tsx
+++ b/app/delete_account.tsx
@@ -65,9 +65,6 @@ const DeleteAccount = () => {
       }
 
       await logout();
-      queryClient.removeQueries({
-        queryKey: PUPPY_QUERY_KEYS.puppyInfo,
-      });
       goHomeAndClearStack();
     } catch (err: unknown) {
       await logout();

--- a/app/home.tsx
+++ b/app/home.tsx
@@ -48,6 +48,9 @@ import { Image as Gif } from 'expo-image';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+// 3초 후 자동으로 사라지는 메시지 키 (그 외는 관련 UI가 닫힐 때까지 유지)
+const TRANSIENT_MESSAGE_KEYS = ['default', 'archiveSuccess'] as const;
+
 export default function HomeScreen() {
   const renamePuppyMutation = useRenamePuppyMutation();
   const renameUserMutation = useRenameUserMutation();
@@ -138,14 +141,21 @@ export default function HomeScreen() {
 
   const handleDrinkRecordPress = () => {
     logButtonTap('drink_record');
-    setShowMessage(true);
-    setRecordMode(!recordMode);
+    const willOpen = !recordMode;
+    setRecordMode(willOpen);
     setShowNameInput(false);
     setInputType(null);
     setRecordType(null);
-    setMessageKey('default');
     setAdviceMessage('');
     setRenameMessage('');
+    if (willOpen) {
+      // 기록 모드 진입: '음주 기록할래' 안내(default, 3초)
+      setMessageKey('default');
+      setShowMessage(true);
+    } else {
+      // 기록 모드 해제(버튼 비활성화): 말풍선 숨김
+      setShowMessage(false);
+    }
   };
 
   const handleCancel = () => {
@@ -153,17 +163,24 @@ export default function HomeScreen() {
     setShowNameInput(false);
     setInputType(null);
     setRecordType(null);
-    setMessageKey('default');
+    // 취소(버튼 비활성화): 안내 말풍선 숨김
+    setShowMessage(false);
   };
 
   const handleShowGoalOptions = () => {
     setShowNameInput(false);
-    setShowMessage(true);
     setAdviceMessage('');
     setRenameMessage('');
     setShowGoalOptions((prev) => {
       const newState = !prev;
-      setMessageKey(newState ? 'makeGoal' : 'default');
+      if (newState) {
+        // 목표 설정 진입: '목표를 선택해주세요' 안내(makeGoal, 유지)
+        setMessageKey('makeGoal');
+        setShowMessage(true);
+      } else {
+        // 목표 설정 닫기(버튼 비활성화): 말풍선 숨김
+        setShowMessage(false);
+      }
       setGoalType(null);
       setShowGoalInput(false);
       return newState;
@@ -302,16 +319,24 @@ export default function HomeScreen() {
     inputType === 'dog' ? '이름을 입력해주세요.' : '이름을 입력해주세요.';
 
   useEffect(() => {
-    if (showMessage) {
-      const timer = setTimeout(() => {
-        setShowMessage(false);
-        setMessageKey('default');
-        setAdviceMessage('');
-        setRenameMessage('');
-      }, 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [showMessage]);
+    if (!showMessage) return;
+
+    // A그룹(조언/음주 기록/기록 완료/이름 등록 완료)만 3초 후 자동으로 사라짐.
+    // B그룹(이름 짓기/목표 설정&새로운 목표 설정/음주 기록 선택-어제&오늘)은 관련 UI가 닫힐 때까지 유지.
+    const isTransient =
+      !!renameMessage ||
+      !!adviceMessage ||
+      (TRANSIENT_MESSAGE_KEYS as readonly string[]).includes(messageKey);
+    if (!isTransient) return;
+
+    const timer = setTimeout(() => {
+      setShowMessage(false);
+      setMessageKey('default');
+      setAdviceMessage('');
+      setRenameMessage('');
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [showMessage, messageKey, renameMessage, adviceMessage]);
 
   const handleRecordDrinkHistory = async (didDrink: boolean) => {
     try {
@@ -495,6 +520,8 @@ export default function HomeScreen() {
                       setShowGoalInput(false);
                       setShowGoalOptions(false);
                       setGoalCount(10);
+                      // 목표 설정 취소(버튼 비활성화): 안내 말풍선 숨김
+                      setShowMessage(false);
                     }}
                     style={{
                       opacity: 0.9,
@@ -545,6 +572,8 @@ export default function HomeScreen() {
                       setShowGoalInput(false);
                       setShowGoalOptions(false);
                       setGoalCount(0);
+                      // 목표 설정 완료(다음 단계): 안내 말풍선 숨김
+                      setShowMessage(false);
                     }}
                     style={{
                       opacity: 0.7,
@@ -573,6 +602,8 @@ export default function HomeScreen() {
                           setGoalType('same');
                           setShowGoalInput(false);
                           setShowGoalOptions(false);
+                          // 목표 설정 완료(다음 단계): 안내 말풍선 숨김
+                          setShowMessage(false);
 
                           await createGoalMutation.mutateAsync({
                             goal: 0,

--- a/app/home.tsx
+++ b/app/home.tsx
@@ -272,8 +272,16 @@ export default function HomeScreen() {
     logButtonTap('advice');
     try {
       const result = await advicePuppyMutation.mutateAsync();
-      setAdviceMessage(result.result.advice || '');
+      const advice = result.result.advice?.trim();
+      if (advice) {
+        setAdviceMessage(advice);
+      } else {
+        // 성공했지만 빈 응답: 범용 멘트(default)로 fallback
+        setAdviceMessage('');
+        setMessageKey('default');
+      }
     } catch {
+      // 실패: 범용 멘트(default)로 fallback
       setAdviceMessage('');
       setMessageKey('default');
     }

--- a/app/home.tsx
+++ b/app/home.tsx
@@ -123,6 +123,8 @@ export default function HomeScreen() {
     setInputType('dog');
     setShowNameInput(true);
     setMessageKey('namingPuppy');
+    setRenameMessage('');
+    setAdviceMessage('');
   };
 
   const handleUserNameButtonPress = () => {
@@ -130,6 +132,8 @@ export default function HomeScreen() {
     setInputType('user');
     setShowNameInput(true);
     setMessageKey('namingUser');
+    setRenameMessage('');
+    setAdviceMessage('');
   };
 
   const handleDrinkRecordPress = () => {
@@ -141,6 +145,7 @@ export default function HomeScreen() {
     setRecordType(null);
     setMessageKey('default');
     setAdviceMessage('');
+    setRenameMessage('');
   };
 
   const handleCancel = () => {
@@ -302,6 +307,7 @@ export default function HomeScreen() {
         setShowMessage(false);
         setMessageKey('default');
         setAdviceMessage('');
+        setRenameMessage('');
       }, 3000);
       return () => clearTimeout(timer);
     }
@@ -310,6 +316,7 @@ export default function HomeScreen() {
   const handleRecordDrinkHistory = async (didDrink: boolean) => {
     try {
       setMessageKey('archiveSuccess');
+      setShowMessage(true);
       setRecordMode(false);
       setRecordType(null);
 
@@ -610,6 +617,7 @@ export default function HomeScreen() {
                         onPress={() => {
                           setRecordType('yesterday');
                           setMessageKey('archiveYesterday');
+                          setShowMessage(true);
                         }}
                         disabled={
                           isRecorded && isRecorded.yesterdayRecorded === true
@@ -624,6 +632,7 @@ export default function HomeScreen() {
                         onPress={() => {
                           setRecordType('today');
                           setMessageKey('archiveToday');
+                          setShowMessage(true);
                         }}
                         disabled={
                           isRecorded && isRecorded.todayRecorded === true

--- a/app/test/proceeding.tsx
+++ b/app/test/proceeding.tsx
@@ -1,4 +1,6 @@
+import { QUERY_KEYS } from '@/hooks/queries/queryKeys';
 import { TestApi } from '@/services/testData';
+import { useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
 import {
@@ -108,6 +110,7 @@ const questions: Question[] = [
 ];
 
 export default function TestProceeding() {
+  const queryClient = useQueryClient();
   const [step, setStep] = useState(1);
   const [selected, setSelected] = useState<number[]>([0, 0, 0, 0, 0, 0, 0]); // 0: default, 1: 첫번째, 2: 두번째. 0번째 index dummy
 
@@ -133,6 +136,16 @@ export default function TestProceeding() {
 
         console.log('제출 성공:', res.message);
         console.log('제출 성공:', res.result);
+
+        // 문제: 탈퇴 -> 로그인 -> 저장공간 삭제 -> 앱 재실행 후 로그인 -> 강아지 테스트 시에 테스트를 2번 하는 오류
+        // 원인: 로그인 화면에서 isNewUser: true을 받고 home으로 간 후 다시 온보딩 화면으로 돌아옴으로써 isOnboarded: false이 됨.
+        // 임시 해결(로직이 비효율적): 온보딩 완료 후 서버 상태(isOnboarded)를 다시 받아 캐시를 갱신한다
+        // 근본 해결: 소셜 로그인 api(카카오 및 애플)에 isOnboarded 값 필요 (서버에 요청 예정)
+        await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.me });
+        await queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.puppyInfo,
+        });
+
         router.replace({
           pathname: '/test/result',
           params: { result: JSON.stringify(res.result) },

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { loginAPI } from '@/services/auth';
 import { deleteFcmToken } from '@/utils/fcm';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   createContext,
   PropsWithChildren,
@@ -18,6 +19,7 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: PropsWithChildren) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const queryClient = useQueryClient();
 
   const logout = useCallback(async () => {
     await deleteFcmToken();
@@ -29,8 +31,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
       }
     } finally {
       setIsLoggedIn(false);
+      // 이전 계정의 데이터(음주 기록 여부, 캘린더 등)가 남지 않도록 캐시를 모두 비운다
+      queryClient.clear();
     }
-  }, []);
+  }, [queryClient]);
 
   const value = useMemo(
     () => ({ isLoggedIn, logout }),


### PR DESCRIPTION
<!-- PR 제목은 이슈와 동일하게 작성하기 -->
<!-- [feat] 여러 이슈인 경우 공통 주제로 묶기 (#14, #15, #16) -->

## 관련 이슈
closes #99 

## 작업 내용
- 로그아웃/회원 탈퇴 시 React Query 캐시 초기화
  → 데이터 캐시 문제 해결
- 온보딩 완료 후 서버 상태(isOnboarded)를 다시 받아 캐시를 갱신
  → 온보딩 2회 시도하는 데이터 캐시 문제 임시 해결
- 이전 메시지 캐시에 가려 잘 안 뜨던 부분 수정
  ‐ 음주 기록
  ‐ 어제/오늘 기록
  ‐ 기록 완료
  ‐ 사용자 이름
- 홈 말풍선 메시지 표시 시간을 메시지 성격에 따라 분리
  - 완료/순간성 메시지 → 3초 후 사라짐
    - 조언, 음주 기록, 기록 완료, 이름 등록 완료
  - 안내/프롬프트 메시지 → 관련 UI(버튼/입력)가 떠 있는 동안 계속 유지
    - 이름 등록, 목표 설정, 새로운 목표 설정, 음주 기록 선택
    → 취소·완료·토글 off 시 default 멘트 잔상 대신 말풍선 숨김 처리
- 메시지 표시 중 버튼을 다시 누르면, 그 시점부터 3초간 더 유지되도록 수정(3초 메시지의 경우)

## 스크린샷 (UI 변경 시)
**Before**
- 데이터 캐시 문제 - 음주 기록 및 캘린더
https://github.com/user-attachments/assets/10429bf5-2b63-4df0-911f-b306c3dbac51
- 메시지 덮어쓰기 문제
https://github.com/user-attachments/assets/b3f4bef3-66e5-48ab-8ea8-687a57e845a8

**After**
- 3초 분리까지 완료
https://github.com/user-attachments/assets/64839feb-5975-4186-bc7b-f4eb7764773a

## 체크리스트
- [x] 동작 확인
- [x] Assignees 지정
- [x] Labels 지정







