### PR TITLE
[refactor] 온보딩 유형 테스트 - 강아지 Gif 이미지 내장하기

### DIFF
--- a/app/home.tsx
+++ b/app/home.tsx
@@ -17,7 +17,6 @@ import { TopBar } from '@/components/page/home/TopBar';
 import { UpdatePopupModal } from '@/components/page/home/UpdatePopupModal';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
-// import { APP_VERSION } from '@/constants/appVersion';
 import { PUPPY_MESSAGES } from '@/constants/messages';
 import { useAdvicePuppyMutation } from '@/hooks/mutations/useAdvicePuppyMutation';
 import { useCreateDrinkHistoryMutation } from '@/hooks/mutations/useCreateDrinkHistoryMutation';

--- a/app/test/result.tsx
+++ b/app/test/result.tsx
@@ -1,4 +1,5 @@
 import ResultBG from '@/assets/images/test/result-bg.svg';
+import { getPuppyGifSource } from '@/utils/dogMapper';
 import { Image as ExpoImage } from 'expo-image';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useEffect, useRef } from 'react';
@@ -22,7 +23,9 @@ const TestResult = () => {
     result: string;
   }>();
 
-  const { type, puppyBreedKo, puppyBreedEn, imageUrl } = JSON.parse(result);
+  const { type, puppyBreedKo, puppyBreedEn } = JSON.parse(result);
+
+  const puppyGifSource = getPuppyGifSource(puppyBreedKo, 1, 'normal');
 
   const cardSlideAnim = useRef(
     new Animated.Value(-SCREEN_HEIGHT * 0.6),
@@ -56,14 +59,9 @@ const TestResult = () => {
       >
         <View style={styles.innerBox}>
           <ExpoImage
-            source={{ uri: imageUrl }}
-            style={{ width: 148, height: 160 }}
+            source={puppyGifSource}
+            style={{ width: 220, height: 238 }}
             contentFit='cover'
-            cachePolicy='disk'
-            onError={(e) => {
-              console.log('Image load error:', e);
-              console.log('imageUrl:', imageUrl);
-            }}
           />
         </View>
       </Animated.View>


### PR DESCRIPTION
<!-- PR 제목은 이슈와 동일하게 작성하기 -->
<!-- [feat] 여러 이슈인 경우 공통 주제로 묶기 (#14, #15, #16) -->

## 관련 이슈
closes #79 

## 작업 내용
- 온보딩 테스트 결과 강아지 이미지를 원격 URL에서 로컬 GIF로 변경
  으로 인한 속도 개선

## 스크린샷 (UI 변경 시)
**Before**
- https://github.com/user-attachments/assets/5c6851f6-2537-45a2-a6bf-be5d5a524cf6

**After**
- https://github.com/user-attachments/assets/291a43b6-7875-4d17-a382-15999d792947

## 체크리스트
- [x] 동작 확인
- [x] Assignees 지정
- [x] Labels 지정
