### PR TITLE
[fix] FCM push 알림 기능 정상 동작 (#101)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,7 @@ allprojects {
     mavenCentral()
     maven { url 'https://www.jitpack.io' }
     maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
+    maven { url "$rootDir/../node_modules/@notifee/react-native/android/libs" }
   }
 }
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,7 +3,7 @@ import { CrashlyticsRouteTracker } from '@/components/common/CrashlyticsRouteTra
 import { AuthProvider } from '@/contexts/AuthContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import theme from '@/styles/theme';
-import { setupTokenRefreshListener } from '@/utils/fcm';
+import { setupForegroundNotificationHandler, setupTokenRefreshListener } from '@/utils/fcm';
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react';
 import crashlytics from '@react-native-firebase/crashlytics';
 import {
@@ -100,6 +100,11 @@ export default function RootLayout() {
 
   useEffect(() => {
     const unsubscribe = setupTokenRefreshListener();
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = setupForegroundNotificationHandler();
     return unsubscribe;
   }, []);
 

--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -10,10 +10,14 @@ import {
 } from '@/hooks/queries/useNotificationSettingQuery';
 import { PUPPY_QUERY_KEYS } from '@/hooks/queries/usePuppyInfoQuery';
 import { useQueryClient } from '@tanstack/react-query';
+import messaging from '@react-native-firebase/messaging';
 import { router } from 'expo-router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
+  Alert,
+  AppState,
   Image,
+  Linking,
   StyleSheet,
   Switch,
   Text,
@@ -34,6 +38,53 @@ const Setting = () => {
   const { data: notificationSetting } = useNotificationSettingQuery();
   const { mutate: updateNotificationSetting } =
     useUpdateNotificationSettingMutation();
+
+  const [hasNotifPermission, setHasNotifPermission] = useState(false);
+
+  useEffect(() => {
+    messaging().hasPermission().then((status) => {
+      setHasNotifPermission(
+        status === messaging.AuthorizationStatus.AUTHORIZED ||
+          status === messaging.AuthorizationStatus.PROVISIONAL,
+      );
+    });
+  }, []);
+
+  const handleNotificationToggle = (value: boolean) => {
+    if (value && !hasNotifPermission) {
+      Alert.alert(
+        '알림 권한 필요',
+        '푸시 알림을 받으려면 기기 설정에서 알림을 허용해주세요.',
+        [
+          { text: '취소', style: 'cancel' },
+          {
+            text: '설정 열기',
+            onPress: () => {
+              Linking.openSettings();
+              const subscription = AppState.addEventListener(
+                'change',
+                async (nextState) => {
+                  if (nextState === 'active') {
+                    subscription.remove();
+                    const newStatus = await messaging().hasPermission();
+                    const nowGranted =
+                      newStatus === messaging.AuthorizationStatus.AUTHORIZED ||
+                      newStatus === messaging.AuthorizationStatus.PROVISIONAL;
+                    if (nowGranted) {
+                      setHasNotifPermission(true);
+                      updateNotificationSetting(true);
+                    }
+                  }
+                },
+              );
+            },
+          },
+        ],
+      );
+      return;
+    }
+    updateNotificationSetting(value);
+  };
 
   // useEffect(() => {
   //   crashlytics().log('screen: /setting mounted');
@@ -76,7 +127,7 @@ const Setting = () => {
         <Text style={styles.text}>알림 수신</Text>
         <Switch
           value={notificationSetting?.receiveNotifications ?? false}
-          onValueChange={(value) => updateNotificationSetting(value)}
+          onValueChange={handleNotificationToggle}
           trackColor={{ false: '#E0E0E0', true: '#00A775' }}
           thumbColor='#ffffff'
         />

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.14.0",
         "@expo/vector-icons": "^14.1.0",
         "@hookform/resolvers": "^5.0.1",
+        "@notifee/react-native": "^9.1.8",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-native-firebase/analytics": "^24.0.0",
         "@react-native-firebase/app": "^24.0.0",
@@ -4457,6 +4458,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@notifee/react-native": {
+      "version": "9.1.8",
+      "resolved": "https://registry.npmjs.org/@notifee/react-native/-/react-native-9.1.8.tgz",
+      "integrity": "sha512-Az/dueoPerJsbbjRxu8a558wKY+gONUrfoy3Hs++5OqbeMsR0dYe6P+4oN6twrLFyzAhEA1tEoZRvQTFDRmvQg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native": "*"
       }
     },
     "node_modules/@open-draft/deferred-promise": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/react": "^11.14.0",
     "@expo/vector-icons": "^14.1.0",
     "@hookform/resolvers": "^5.0.1",
+    "@notifee/react-native": "^9.1.8",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-firebase/analytics": "^24.0.0",
     "@react-native-firebase/app": "^24.0.0",

--- a/utils/fcm.ts
+++ b/utils/fcm.ts
@@ -1,20 +1,57 @@
 import { KEYS } from '@/constants/storage';
 import { fcmAPI } from '@/services/fcm';
-import notifee, { AndroidImportance } from '@notifee/react-native';
+import { notificationAPI } from '@/services/notification';
+import notifee, { AndroidImportance, AuthorizationStatus } from '@notifee/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import messaging from '@react-native-firebase/messaging';
+import { Alert, AppState, Linking } from 'react-native';
+
+async function registerFcmTokenAndEnableNotification(): Promise<void> {
+  const token = await messaging().getToken();
+  await fcmAPI.registerToken(token);
+  await notificationAPI.updateSettings(true);
+}
 
 export async function requestPermissionAndRegisterFcmToken(): Promise<void> {
   try {
-    const authStatus = await messaging().requestPermission();
+    const settings = await notifee.requestPermission();
     const enabled =
-      authStatus === messaging.AuthorizationStatus.AUTHORIZED ||
-      authStatus === messaging.AuthorizationStatus.PROVISIONAL;
+      settings.authorizationStatus === AuthorizationStatus.AUTHORIZED ||
+      settings.authorizationStatus === AuthorizationStatus.PROVISIONAL;
 
-    if (!enabled) return;
+    if (!enabled) {
+      Alert.alert(
+        '알림 권한 필요',
+        '푸시 알림을 받으려면 기기 설정에서 알림을 허용해주세요.',
+        [
+          { text: '취소', style: 'cancel' },
+          {
+            text: '설정 열기',
+            onPress: () => {
+              Linking.openSettings();
+              const subscription = AppState.addEventListener(
+                'change',
+                async (nextState) => {
+                  if (nextState === 'active') {
+                    subscription.remove();
+                    const newSettings = await notifee.getNotificationSettings();
+                    const nowGranted =
+                      newSettings.authorizationStatus ===
+                      AuthorizationStatus.AUTHORIZED;
+                    if (nowGranted) {
+                      await registerFcmTokenAndEnableNotification();
+                    }
+                  }
+                },
+              );
+            },
+          },
+        ],
+      );
+      return;
+    }
 
-    const token = await messaging().getToken();
-    await fcmAPI.registerToken(token);
+    await registerFcmTokenAndEnableNotification();
   } catch (e) {
     console.error('FCM 권한 요청 및 토큰 등록 실패:', e);
   }

--- a/utils/fcm.ts
+++ b/utils/fcm.ts
@@ -14,7 +14,6 @@ export async function requestPermissionAndRegisterFcmToken(): Promise<void> {
     if (!enabled) return;
 
     const token = await messaging().getToken();
-    console.log('[FCM Token]', token); // TODO: 임시 확인용 로그, 추후 제거
     await fcmAPI.registerToken(token);
   } catch (e) {
     console.error('FCM 권한 요청 및 토큰 등록 실패:', e);
@@ -30,7 +29,10 @@ export async function deleteFcmToken(): Promise<void> {
   }
 }
 
-export async function displayLocalNotification(title: string, body: string): Promise<void> {
+export async function displayLocalNotification(
+  title: string,
+  body: string,
+): Promise<void> {
   try {
     const channelId = await notifee.createChannel({
       id: 'default',

--- a/utils/fcm.ts
+++ b/utils/fcm.ts
@@ -1,5 +1,6 @@
 import { KEYS } from '@/constants/storage';
 import { fcmAPI } from '@/services/fcm';
+import notifee, { AndroidImportance } from '@notifee/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import messaging from '@react-native-firebase/messaging';
 
@@ -13,6 +14,7 @@ export async function requestPermissionAndRegisterFcmToken(): Promise<void> {
     if (!enabled) return;
 
     const token = await messaging().getToken();
+    console.log('[FCM Token]', token); // TODO: 임시 확인용 로그, 추후 제거
     await fcmAPI.registerToken(token);
   } catch (e) {
     console.error('FCM 권한 요청 및 토큰 등록 실패:', e);
@@ -26,6 +28,27 @@ export async function deleteFcmToken(): Promise<void> {
   } catch (e) {
     console.error('FCM 토큰 삭제 실패:', e);
   }
+}
+
+export async function displayLocalNotification(title: string, body: string): Promise<void> {
+  try {
+    const channelId = await notifee.createChannel({
+      id: 'default',
+      name: '기본 알림',
+      importance: AndroidImportance.HIGH,
+    });
+    await notifee.displayNotification({ title, body, android: { channelId } });
+  } catch (e) {
+    console.error('로컬 알림 표시 실패:', e);
+  }
+}
+
+export function setupForegroundNotificationHandler(): () => void {
+  return messaging().onMessage(async (remoteMessage) => {
+    const title = remoteMessage.notification?.title ?? '알림';
+    const body = remoteMessage.notification?.body ?? '';
+    await displayLocalNotification(title, body);
+  });
 }
 
 export function setupTokenRefreshListener(): () => void {


### PR DESCRIPTION
<!-- PR 제목은 이슈와 동일하게 작성하기 -->
<!-- [feat] 여러 이슈인 경우 공통 주제로 묶기 (#14, #15, #16) -->

## 관련 이슈
closes #101 

## 작업 내용
1. **포그라운드 푸시 알림 처리 (`notifee` 설치)**
  \- `android/build.gradle`: notifee Maven 저장소 추가
  \- `utils/fcm.ts`: `displayLocalNotification()`, `setupForegroundNotificationHandler()` 추가
  \- `app/_layout.tsx`: 포그라운드 메시지 핸들러 등록

2. **알림 권한 체크 방식 수정**
  \- `messaging().requestPermission()` → `notifee.requestPermission()`으로 교체
  \- 기존 방식은 Android에서 OS 알림 표시 권한 무시하고 항상 AUTHORIZED 반환하는 버그 수정

3. **로그인 시 알림 권한 거부 안내**
  \- `utils/fcm.ts`: 권한 거부 시 "기기 설정에서 허용해주세요" Alert + "설정 열기" 버튼
  \- 설정 앱에서 허용 후 복귀하면 자동으로 FCM 토큰 등록 + `receiveNotifications = true` 설정

4. **설정 페이지 토글 개선**
  \- `app/setting.tsx`: 마운트 시 권한 상태 미리 조회해서 캐시 → 토글 탭 시 딜레이 없이 즉시 반응(낙관적 업데이트)
  \- 권한 거부 상태에서 토글 ON 시 "설정 열기" 안내 + 복귀 시 자동 활성화


## 스크린샷
| 알람 설정 전 | 알람 설정 후 |
| ------ | ----- |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/015236ab-1946-47e7-b25b-a4443d699ed6" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/3c6118a1-d790-4361-bcee-b2044533b688" /> |

## 체크리스트
- [x] 동작 확인
- [x] Assignees 지정
- [x] Labels 지정
