### PR TITLE
[fix] 푸시 알림 권한 허용 후 앱 내 알림 설정이 동기화되지 않는 문제 (#105)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -95,7 +95,7 @@ android {
         applicationId 'com.anonymous.puppymode'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 17
+        versionCode 18
         versionName "1.0.7"
     }
     signingConfigs {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
@@ -16,6 +16,7 @@
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
+    <meta-data android:name="com.google.firebase.messaging.default_notification_channel_id" android:value="default" tools:replace="android:value"/>
     <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/app.json
+++ b/app.json
@@ -31,6 +31,7 @@
       "@react-native-firebase/app",
       "@react-native-firebase/crashlytics",
       "@react-native-firebase/messaging",
+      "./plugins/withDefaultNotificationChannel",
       [
         "@react-native-seoul/kakao-login",
         {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,7 +3,7 @@ import { CrashlyticsRouteTracker } from '@/components/common/CrashlyticsRouteTra
 import { AuthProvider } from '@/contexts/AuthContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import theme from '@/styles/theme';
-import { setupForegroundNotificationHandler, setupTokenRefreshListener } from '@/utils/fcm';
+import { createDefaultChannel, setupForegroundNotificationHandler, setupTokenRefreshListener } from '@/utils/fcm';
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react';
 import crashlytics from '@react-native-firebase/crashlytics';
 import {
@@ -101,6 +101,12 @@ export default function RootLayout() {
   useEffect(() => {
     const unsubscribe = setupTokenRefreshListener();
     return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    createDefaultChannel().catch((e) =>
+      console.error('기본 알림 채널 생성 실패:', e),
+    );
   }, []);
 
   useEffect(() => {

--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -4,6 +4,7 @@ import SettingBtn from '@/components/page/setting/SettingBtn';
 import { APP_VERSION } from '@/constants/appVersion';
 import { POLICY_MESSAGES } from '@/constants/messages';
 import { useAuth } from '@/contexts/AuthContext';
+import { useEnableNotifications } from '@/hooks/notifications/useEnableNotifications';
 import {
   useNotificationSettingQuery,
   useUpdateNotificationSettingMutation,
@@ -14,10 +15,7 @@ import messaging from '@react-native-firebase/messaging';
 import { router } from 'expo-router';
 import { useEffect, useState } from 'react';
 import {
-  Alert,
-  AppState,
   Image,
-  Linking,
   StyleSheet,
   Switch,
   Text,
@@ -38,6 +36,7 @@ const Setting = () => {
   const { data: notificationSetting } = useNotificationSettingQuery();
   const { mutate: updateNotificationSetting } =
     useUpdateNotificationSettingMutation();
+  const { requestAndEnable } = useEnableNotifications();
 
   const [hasNotifPermission, setHasNotifPermission] = useState(false);
 
@@ -52,35 +51,7 @@ const Setting = () => {
 
   const handleNotificationToggle = (value: boolean) => {
     if (value && !hasNotifPermission) {
-      Alert.alert(
-        '알림 권한 필요',
-        '푸시 알림을 받으려면 기기 설정에서 알림을 허용해주세요.',
-        [
-          { text: '취소', style: 'cancel' },
-          {
-            text: '설정 열기',
-            onPress: () => {
-              Linking.openSettings();
-              const subscription = AppState.addEventListener(
-                'change',
-                async (nextState) => {
-                  if (nextState === 'active') {
-                    subscription.remove();
-                    const newStatus = await messaging().hasPermission();
-                    const nowGranted =
-                      newStatus === messaging.AuthorizationStatus.AUTHORIZED ||
-                      newStatus === messaging.AuthorizationStatus.PROVISIONAL;
-                    if (nowGranted) {
-                      setHasNotifPermission(true);
-                      updateNotificationSetting(true);
-                    }
-                  }
-                },
-              );
-            },
-          },
-        ],
-      );
+      requestAndEnable();
       return;
     }
     updateNotificationSetting(value);

--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -10,12 +10,14 @@ import {
   useUpdateNotificationSettingMutation,
 } from '@/hooks/queries/useNotificationSettingQuery';
 import { PUPPY_QUERY_KEYS } from '@/hooks/queries/usePuppyInfoQuery';
-import { useQueryClient } from '@tanstack/react-query';
 import messaging from '@react-native-firebase/messaging';
-import { router } from 'expo-router';
-import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { router, useFocusEffect } from 'expo-router';
+import { useCallback, useState } from 'react';
 import {
+  AppState,
   Image,
+  Linking,
   StyleSheet,
   Switch,
   Text,
@@ -40,14 +42,31 @@ const Setting = () => {
 
   const [hasNotifPermission, setHasNotifPermission] = useState(false);
 
-  useEffect(() => {
-    messaging().hasPermission().then((status) => {
-      setHasNotifPermission(
-        status === messaging.AuthorizationStatus.AUTHORIZED ||
-          status === messaging.AuthorizationStatus.PROVISIONAL,
-      );
-    });
+  const checkPermission = useCallback(async () => {
+    const status = await messaging().hasPermission();
+    setHasNotifPermission(
+      status === messaging.AuthorizationStatus.AUTHORIZED ||
+        status === messaging.AuthorizationStatus.PROVISIONAL,
+    );
   }, []);
+
+  // 화면 진입 시, 그리고 OS 설정에서 권한을 바꾸고 앱으로 복귀했을 때
+  // OS 권한 상태를 다시 읽어 안내 배너를 최신으로 유지한다.
+  useFocusEffect(
+    useCallback(() => {
+      checkPermission();
+      const subscription = AppState.addEventListener('change', (nextState) => {
+        if (nextState === 'active') {
+          checkPermission();
+        }
+      });
+      return () => subscription.remove();
+    }, [checkPermission]),
+  );
+
+  // OS 권한은 거부됐는데 서버 설정은 켜져 있는 상태(조용한 실패, 토글은 ON).
+  const showPermissionNotice =
+    !hasNotifPermission && !!notificationSetting?.receiveNotifications;
 
   const handleNotificationToggle = (value: boolean) => {
     if (value && !hasNotifPermission) {
@@ -103,6 +122,19 @@ const Setting = () => {
           thumbColor='#ffffff'
         />
       </View>
+
+      {showPermissionNotice && (
+        <TouchableOpacity
+          style={styles.permissionNotice}
+          activeOpacity={0.7}
+          onPress={() => Linking.openSettings()}
+        >
+          <Text style={styles.permissionNoticeText}>
+            기기 알림이 꺼져 있어 알림을 받을 수 없어요.
+          </Text>
+          <Text style={styles.permissionNoticeAction}>설정 열기</Text>
+        </TouchableOpacity>
+      )}
 
       <SettingBtn
         title='이용약관'
@@ -205,5 +237,25 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '400',
     lineHeight: 22,
+  },
+  permissionNotice: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    backgroundColor: '#FFF4F4',
+  },
+  permissionNoticeText: {
+    flex: 1,
+    color: '#D14343',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  permissionNoticeAction: {
+    marginLeft: 12,
+    color: '#D14343',
+    fontSize: 13,
+    fontWeight: '600',
   },
 });

--- a/hooks/auth/useAppleLogin.ts
+++ b/hooks/auth/useAppleLogin.ts
@@ -1,99 +1,102 @@
+import { useEnableNotifications } from '@/hooks/notifications/useEnableNotifications';
 import { KEYS } from '@/constants/storage';
 import { axiosInstance } from '@/services/index';
-import { requestPermissionAndRegisterFcmToken } from '@/utils/fcm';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as AppleAuthentication from 'expo-apple-authentication';
 import { router } from 'expo-router';
+import { useCallback } from 'react';
 import { Alert } from 'react-native';
 
-async function handleSignInApple() {
-  try {
-    const credential = await AppleAuthentication.signInAsync({
-      requestedScopes: [
-        AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
-        AppleAuthentication.AppleAuthenticationScope.EMAIL,
-      ],
-    });
-
-    const credentialState = await AppleAuthentication.getCredentialStateAsync(
-      credential.user,
-    );
-
-    if (
-      credentialState !==
-      AppleAuthentication.AppleAuthenticationCredentialState.AUTHORIZED
-    ) {
-      return null;
-    }
-
-    const identityToken = credential.identityToken;
-    const authorizationCode = credential.authorizationCode;
-
-    // ✅ API 스펙상 둘 다 필요
-    if (!identityToken || !authorizationCode) {
-      console.error('Apple 로그인 응답에 token/code가 없습니다.', {
-        identityTokenExists: !!identityToken,
-        authorizationCodeExists: !!authorizationCode,
-      });
-      Alert.alert('오류', 'Apple 로그인 정보를 가져오지 못했습니다.');
-      return null;
-    }
-
-    // ✅ username: 최초 1회만 올 수 있음 (없어도 서버가 허용해야 정상)
-    const username =
-      credential.fullName?.givenName || credential.fullName?.familyName
-        ? `${credential.fullName?.familyName ?? ''}${credential.fullName?.givenName ?? ''}`.trim()
-        : undefined;
-
-    try {
-      const backendResponse = await axiosInstance.post('/auth/apple/login', {
-        authorizationCode,
-        identityToken,
-        username, // 없으면 undefined로 빠짐
-      });
-
-      const { result } = backendResponse.data;
-      console.log('[APPLE] isNewUser =', result.userInfo?.isNewUser);
-      console.log('[APPLE] userInfo =', result.userInfo);
-
-      await AsyncStorage.setItem(KEYS.ACCESS_TOKEN, result.accessToken);
-      await AsyncStorage.setItem(KEYS.PROVIDER, 'apple');
-      if (result.refreshToken) {
-        await AsyncStorage.setItem(KEYS.REFRESH_TOKEN, result.refreshToken);
-      } else {
-        await AsyncStorage.removeItem(KEYS.REFRESH_TOKEN);
-      }
-      requestPermissionAndRegisterFcmToken();
-      if (result.userInfo?.isNewUser) {
-        router.replace('/test/start'); // 강아지 등록/온보딩 화면
-      } else {
-        router.replace('/home');
-      }
-
-      return backendResponse.data;
-    } catch (backendError: any) {
-      console.error(
-        '백엔드 Apple 로그인 실패:',
-        backendError.response?.data || backendError.message,
-      );
-
-      // 서버가 보내주는 message를 그대로 보여주면 디버깅에 도움됨
-      Alert.alert(
-        '로그인 실패',
-        backendError.response?.data?.message ||
-          '서버 통신 중 오류가 발생했습니다.',
-      );
-      return null;
-    }
-  } catch (error: any) {
-    if (error.code === 'ERR_CANCELED') return null;
-
-    console.error('Apple 로그인 에러:', error);
-    Alert.alert('로그인 오류', 'Apple 로그인 중 문제가 발생했습니다.');
-    return null;
-  }
-}
-
 export const useAppleLogin = () => {
+  const { requestAndEnable } = useEnableNotifications();
+
+  const handleSignInApple = useCallback(async () => {
+    try {
+      const credential = await AppleAuthentication.signInAsync({
+        requestedScopes: [
+          AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+          AppleAuthentication.AppleAuthenticationScope.EMAIL,
+        ],
+      });
+
+      const credentialState = await AppleAuthentication.getCredentialStateAsync(
+        credential.user,
+      );
+
+      if (
+        credentialState !==
+        AppleAuthentication.AppleAuthenticationCredentialState.AUTHORIZED
+      ) {
+        return null;
+      }
+
+      const identityToken = credential.identityToken;
+      const authorizationCode = credential.authorizationCode;
+
+      // ✅ API 스펙상 둘 다 필요
+      if (!identityToken || !authorizationCode) {
+        console.error('Apple 로그인 응답에 token/code가 없습니다.', {
+          identityTokenExists: !!identityToken,
+          authorizationCodeExists: !!authorizationCode,
+        });
+        Alert.alert('오류', 'Apple 로그인 정보를 가져오지 못했습니다.');
+        return null;
+      }
+
+      // ✅ username: 최초 1회만 올 수 있음 (없어도 서버가 허용해야 정상)
+      const username =
+        credential.fullName?.givenName || credential.fullName?.familyName
+          ? `${credential.fullName?.familyName ?? ''}${credential.fullName?.givenName ?? ''}`.trim()
+          : undefined;
+
+      try {
+        const backendResponse = await axiosInstance.post('/auth/apple/login', {
+          authorizationCode,
+          identityToken,
+          username, // 없으면 undefined로 빠짐
+        });
+
+        const { result } = backendResponse.data;
+        console.log('[APPLE] isNewUser =', result.userInfo?.isNewUser);
+        console.log('[APPLE] userInfo =', result.userInfo);
+
+        await AsyncStorage.setItem(KEYS.ACCESS_TOKEN, result.accessToken);
+        await AsyncStorage.setItem(KEYS.PROVIDER, 'apple');
+        if (result.refreshToken) {
+          await AsyncStorage.setItem(KEYS.REFRESH_TOKEN, result.refreshToken);
+        } else {
+          await AsyncStorage.removeItem(KEYS.REFRESH_TOKEN);
+        }
+        requestAndEnable();
+        if (result.userInfo?.isNewUser) {
+          router.replace('/test/start'); // 강아지 등록/온보딩 화면
+        } else {
+          router.replace('/home');
+        }
+
+        return backendResponse.data;
+      } catch (backendError: any) {
+        console.error(
+          '백엔드 Apple 로그인 실패:',
+          backendError.response?.data || backendError.message,
+        );
+
+        // 서버가 보내주는 message를 그대로 보여주면 디버깅에 도움됨
+        Alert.alert(
+          '로그인 실패',
+          backendError.response?.data?.message ||
+            '서버 통신 중 오류가 발생했습니다.',
+        );
+        return null;
+      }
+    } catch (error: any) {
+      if (error.code === 'ERR_CANCELED') return null;
+
+      console.error('Apple 로그인 에러:', error);
+      Alert.alert('로그인 오류', 'Apple 로그인 중 문제가 발생했습니다.');
+      return null;
+    }
+  }, [requestAndEnable]);
+
   return { handleSignInApple };
 };

--- a/hooks/auth/useLogin.ts
+++ b/hooks/auth/useLogin.ts
@@ -1,6 +1,6 @@
+import { useEnableNotifications } from '@/hooks/notifications/useEnableNotifications';
 import { KEYS } from '@/constants/storage';
 import { KakaoLoginResult, loginAPI } from '@/services/auth';
-import { requestPermissionAndRegisterFcmToken } from '@/utils/fcm';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { login as loginWithKakaoAccount } from '@react-native-seoul/kakao-login';
 import { useCallback, useState } from 'react';
@@ -18,6 +18,7 @@ export const useLogin = (): UseLoginReturn => {
   const [userInfo, setUserInfo] = useState<KakaoLoginResult['userInfo'] | null>(
     null,
   );
+  const { requestAndEnable } = useEnableNotifications();
 
   const loginWithKakao = useCallback(async () => {
     setIsLoading(true);
@@ -34,7 +35,7 @@ export const useLogin = (): UseLoginReturn => {
 
       await AsyncStorage.setItem(KEYS.ACCESS_TOKEN, result.accessToken);
 
-      requestPermissionAndRegisterFcmToken();
+      requestAndEnable();
 
       setUserInfo(result.userInfo);
     } catch (err: any) {
@@ -43,7 +44,7 @@ export const useLogin = (): UseLoginReturn => {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [requestAndEnable]);
 
   return {
     isLoading,

--- a/hooks/notifications/useEnableNotifications.ts
+++ b/hooks/notifications/useEnableNotifications.ts
@@ -1,0 +1,64 @@
+import { useUpdateNotificationSettingMutation } from '@/hooks/queries/useNotificationSettingQuery';
+import { fcmAPI } from '@/services/fcm';
+import notifee, { AuthorizationStatus } from '@notifee/react-native';
+import messaging from '@react-native-firebase/messaging';
+import { useCallback } from 'react';
+import { Alert, AppState, Linking } from 'react-native';
+
+export const useEnableNotifications = () => {
+  const { mutateAsync: updateNotificationSetting } =
+    useUpdateNotificationSettingMutation();
+
+  const registerTokenAndEnable = useCallback(async () => {
+    const token = await messaging().getToken();
+    await fcmAPI.registerToken(token);
+    await updateNotificationSetting(true);
+  }, [updateNotificationSetting]);
+
+  const requestAndEnable = useCallback(async () => {
+    try {
+      const settings = await notifee.requestPermission();
+      const enabled =
+        settings.authorizationStatus === AuthorizationStatus.AUTHORIZED ||
+        settings.authorizationStatus === AuthorizationStatus.PROVISIONAL;
+
+      if (enabled) {
+        await registerTokenAndEnable();
+        return;
+      }
+
+      Alert.alert(
+        '알림 권한 필요',
+        '푸시 알림을 받으려면 기기 설정에서 알림을 허용해주세요.',
+        [
+          { text: '취소', style: 'cancel' },
+          {
+            text: '설정 열기',
+            onPress: () => {
+              Linking.openSettings();
+              const subscription = AppState.addEventListener(
+                'change',
+                async (nextState) => {
+                  if (nextState === 'active') {
+                    subscription.remove();
+                    const newSettings = await notifee.getNotificationSettings();
+                    const nowGranted =
+                      newSettings.authorizationStatus ===
+                      AuthorizationStatus.AUTHORIZED;
+                    if (nowGranted) {
+                      await registerTokenAndEnable();
+                    }
+                  }
+                },
+              );
+            },
+          },
+        ],
+      );
+    } catch (e) {
+      console.error('FCM 권한 요청 및 토큰 등록 실패:', e);
+    }
+  }, [registerTokenAndEnable]);
+
+  return { requestAndEnable, registerTokenAndEnable };
+};

--- a/plugins/withDefaultNotificationChannel.js
+++ b/plugins/withDefaultNotificationChannel.js
@@ -1,0 +1,41 @@
+const { withAndroidManifest } = require('@expo/config-plugins');
+
+/**
+ * 백그라운드/종료 상태에서 FCM이 알림을 표시할 때 사용할 기본 채널 id를 지정한다.
+ * 이 값이 없으면 OS가 IMPORTANCE_DEFAULT인 fallback 채널을 써서 헤드업 배너가 뜨지 않는다.
+ * 앱이 런타임에 생성하는 채널 id(utils/fcm.ts의 DEFAULT_CHANNEL_ID = 'default')와 일치해야 한다.
+ *
+ * @react-native-firebase/messaging이 같은 meta-data를 빈 값으로 미리 선언하므로,
+ * tools:replace로 값을 덮어써서 매니페스트 머지 충돌을 막는다.
+ */
+const META_NAME = 'com.google.firebase.messaging.default_notification_channel_id';
+const CHANNEL_ID = 'default';
+
+module.exports = function withDefaultNotificationChannel(config) {
+  return withAndroidManifest(config, (cfg) => {
+    const manifest = cfg.modResults.manifest;
+
+    // tools 네임스페이스 보장
+    manifest.$ = manifest.$ || {};
+    if (!manifest.$['xmlns:tools']) {
+      manifest.$['xmlns:tools'] = 'http://schemas.android.com/tools';
+    }
+
+    const application = manifest.application?.[0];
+    if (!application) return cfg;
+
+    application['meta-data'] = application['meta-data'] || [];
+    const metaData = application['meta-data'];
+
+    let item = metaData.find((m) => m.$?.['android:name'] === META_NAME);
+    if (!item) {
+      item = { $: { 'android:name': META_NAME } };
+      metaData.push(item);
+    }
+
+    item.$['android:value'] = CHANNEL_ID;
+    item.$['tools:replace'] = 'android:value';
+
+    return cfg;
+  });
+};

--- a/utils/fcm.ts
+++ b/utils/fcm.ts
@@ -1,61 +1,8 @@
 import { KEYS } from '@/constants/storage';
 import { fcmAPI } from '@/services/fcm';
-import { notificationAPI } from '@/services/notification';
-import notifee, { AndroidImportance, AuthorizationStatus } from '@notifee/react-native';
+import notifee, { AndroidImportance } from '@notifee/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import messaging from '@react-native-firebase/messaging';
-import { Alert, AppState, Linking } from 'react-native';
-
-async function registerFcmTokenAndEnableNotification(): Promise<void> {
-  const token = await messaging().getToken();
-  await fcmAPI.registerToken(token);
-  await notificationAPI.updateSettings(true);
-}
-
-export async function requestPermissionAndRegisterFcmToken(): Promise<void> {
-  try {
-    const settings = await notifee.requestPermission();
-    const enabled =
-      settings.authorizationStatus === AuthorizationStatus.AUTHORIZED ||
-      settings.authorizationStatus === AuthorizationStatus.PROVISIONAL;
-
-    if (!enabled) {
-      Alert.alert(
-        '알림 권한 필요',
-        '푸시 알림을 받으려면 기기 설정에서 알림을 허용해주세요.',
-        [
-          { text: '취소', style: 'cancel' },
-          {
-            text: '설정 열기',
-            onPress: () => {
-              Linking.openSettings();
-              const subscription = AppState.addEventListener(
-                'change',
-                async (nextState) => {
-                  if (nextState === 'active') {
-                    subscription.remove();
-                    const newSettings = await notifee.getNotificationSettings();
-                    const nowGranted =
-                      newSettings.authorizationStatus ===
-                      AuthorizationStatus.AUTHORIZED;
-                    if (nowGranted) {
-                      await registerFcmTokenAndEnableNotification();
-                    }
-                  }
-                },
-              );
-            },
-          },
-        ],
-      );
-      return;
-    }
-
-    await registerFcmTokenAndEnableNotification();
-  } catch (e) {
-    console.error('FCM 권한 요청 및 토큰 등록 실패:', e);
-  }
-}
 
 export async function deleteFcmToken(): Promise<void> {
   try {

--- a/utils/fcm.ts
+++ b/utils/fcm.ts
@@ -66,16 +66,22 @@ export async function deleteFcmToken(): Promise<void> {
   }
 }
 
+export const DEFAULT_CHANNEL_ID = 'default';
+
+export async function createDefaultChannel(): Promise<string> {
+  return notifee.createChannel({
+    id: DEFAULT_CHANNEL_ID,
+    name: '기본 알림',
+    importance: AndroidImportance.HIGH,
+  });
+}
+
 export async function displayLocalNotification(
   title: string,
   body: string,
 ): Promise<void> {
   try {
-    const channelId = await notifee.createChannel({
-      id: 'default',
-      name: '기본 알림',
-      importance: AndroidImportance.HIGH,
-    });
+    const channelId = await createDefaultChannel();
     await notifee.displayNotification({ title, body, android: { channelId } });
   } catch (e) {
     console.error('로컬 알림 표시 실패:', e);


### PR DESCRIPTION
<!-- PR 제목은 이슈와 동일하게 작성하기 -->
<!-- [feat] 여러 이슈인 경우 공통 주제로 묶기 (#14, #15, #16) -->

## 관련 이슈
closes #105

## 작업 내용
**01\. 앱 시작 시 알림 채널 미리 생성하도록 수정**

**02\. 알림 권한 플로우를 공통 훅으로 통합**
- 로그인 복구 플로우가 원시 API로 서버 설정을 갱신해 React Query 캐시와 어긋나면서,
권한 허용 후에도 설정 토글이 OFF로 보이던 문제 해결.
  - `useEnableNotifications` 훅 신설 (서버 반영을 mutation 경유 → 캐시 자동 동기화)
  - `fcm.ts`의 `requestPermissionAndRegisterFcmToken` 등 원시 호출 제거
  - `useLogin` / `useAppleLogin` / `setting` 화면이 공통 훅을 사용하도록 통합
  - 중복되던 권한 복구 로직(Alert→설정 이동→재확인) 일원화

**03\. 기기 알림 꺼짐 안내 - 설정 화면에 배너 추가**
- OS 알림 권한은 거부됐는데 서버 설정은 켜져 있어, 토글은 ON으로 보이지만
  실제 알림이 오지 않는 상태(조용한 실패)를 사용자가 인지하지 못하던 문제 보완.
  - 설정 화면 진입 및 포그라운드 복귀 시 OS 권한 재확인
  - 권한 거부 && 서버 설정 ON일 때만 안내 배너 노출, 탭 시 OS 설정 이동

**04\. 백그라운드 알림도 헤드업 배너로 표시되도록 기본 알림 채널 지정**
- FCM이 백그라운드/종료 상태에서 알림을 띄울 때 importance가 낮은 OS fallback 채널을 사용해 헤드업 배너가 뜨지 않던 문제 개선.
- `default_notification_channel_id`를 앱이 생성하는 HIGH 채널(`'default'`)로
지정해 포그라운드와 동일하게 헤드업이 노출되도록 함.
  - `AndroidManifest`에 `meta-data` 추가
  - `prebuild` 시 유지되도록 `config plugin` 추가 및 `app.json` 등록

## 스크린샷 (UI 변경 시)
| FCM 푸시알림 | 04. 헤드업 배너 |
| ------ | ----- |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/54f80e97-0311-4de0-aed3-423a65422b1e" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/c9712739-b119-4a1a-aa78-81d3fa584f0f" /> |
| | 임시 버튼은 삭제 완료 |

## 체크리스트
- [x] 동작 확인
- [x] Assignees 지정
- [x] Labels 지정
