### PR TITLE
[feat] 온보딩 화면(강아지 이름·내 이름·목표) 추가 (SCRUM-18)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -95,8 +95,8 @@ android {
         applicationId 'com.anonymous.puppymode'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 20
-        versionName "1.2.0"
+        versionCode 22
+        versionName "1.3.1"
     }
     signingConfigs {
         debug {

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "멍멍멍멍멍",
     "slug": "puppymode",
-    "version": "1.2.0",
+    "version": "1.3.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "puppymode",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -178,6 +178,10 @@ export default function RootLayout() {
                   name='test/result'
                   options={{ headerShown: false }}
                 />
+                <Stack.Screen
+                  name='onboarding/index'
+                  options={{ headerShown: false }}
+                />
                 <Stack.Screen name='report' options={{ headerShown: false }} />
                 <Stack.Screen
                   name='calendar'

--- a/app/home.tsx
+++ b/app/home.tsx
@@ -264,9 +264,24 @@ export default function HomeScreen() {
   useEffect(() => {
     if (!puppyInfo || isFetching || hasRedirectedRef.current) return;
 
+    // 강아지 입양 테스트 미완료 → 테스트부터
     if (puppyInfo.isOnboarded === false) {
       hasRedirectedRef.current = true;
       router.replace('/test/start');
+      return;
+    }
+
+    // 테스트는 했지만 목표·이름 설정이 안 되어 있으면 온보딩으로
+    if (
+      !puppyInfo.isGoal ||
+      !puppyInfo.isPuppyName ||
+      !puppyInfo.isMyName
+    ) {
+      hasRedirectedRef.current = true;
+      router.replace({
+        pathname: '/onboarding',
+        params: { breed: puppyInfo.puppyLevelName ?? '' },
+      });
     }
   }, [puppyInfo, isFetching]);
 
@@ -409,6 +424,17 @@ export default function HomeScreen() {
   if (isError) {
     return null;
     // 추후 에러 UI 추가 (문제가 생겼습니다, 로그인 화면으로 이동? 상의 필요)
+  }
+
+  // 온보딩(테스트/목표/이름) 미완료 시 홈 UI를 그리지 않고 리다이렉트를 기다린다.
+  if (
+    puppyInfo &&
+    (puppyInfo.isOnboarded === false ||
+      !puppyInfo.isGoal ||
+      !puppyInfo.isPuppyName ||
+      !puppyInfo.isMyName)
+  ) {
+    return null;
   }
 
   // F3 검색용(임시, 차후 삭제)

--- a/app/home.tsx
+++ b/app/home.tsx
@@ -278,10 +278,7 @@ export default function HomeScreen() {
       !puppyInfo.isMyName
     ) {
       hasRedirectedRef.current = true;
-      router.replace({
-        pathname: '/onboarding',
-        params: { breed: puppyInfo.puppyLevelName ?? '' },
-      });
+      router.replace('/onboarding');
     }
   }, [puppyInfo, isFetching]);
 

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -1,0 +1,189 @@
+import { PrimaryButton } from '@/components/common/buttons/PrimaryButton';
+import { TextInput } from '@/components/common/Inputs/TextInput';
+import { ControlButton } from '@/components/page/home/ControlButton';
+import { OnboardingLayout } from '@/components/page/onboarding/OnboardingLayout';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { useCreateGoalMutation } from '@/hooks/mutations/useCreateGoalMutation';
+import { useRenamePuppyMutation } from '@/hooks/mutations/useRenamePuppyMutation';
+import { useRenameUserMutation } from '@/hooks/mutations/useRenameUserMutation';
+import { useCompleteOnboarding } from '@/hooks/onboarding/useCompleteOnboarding';
+import { logButtonTap } from '@/utils/analytics';
+import { maxDaysInMonth } from '@/utils/dateUtils';
+import { useLocalSearchParams } from 'expo-router';
+import { useState, type ReactNode } from 'react';
+import { Alert, StyleSheet, Text, View } from 'react-native';
+
+type Step = 1 | 2 | 3;
+
+/**
+ * 온보딩 화면 (한 화면, 3단계).
+ * step 1: 강아지 이름 짓기
+ * step 2: 내 이름 알려주기
+ * step 3: 이번 달 목표(음주 허용 횟수) 설정 → (iOS 알림 권한 요청) → 홈
+ * 배경 · 강아지 · 진행 점은 유지되고 타이틀 · 말풍선 · 하단 영역만 바뀐다.
+ */
+export default function Onboarding() {
+  const { breed } = useLocalSearchParams<{ breed?: string }>();
+  const createGoalMutation = useCreateGoalMutation();
+  const renamePuppyMutation = useRenamePuppyMutation();
+  const renameUserMutation = useRenameUserMutation();
+  const { complete } = useCompleteOnboarding();
+
+  const [step, setStep] = useState<Step>(1);
+  const [dogName, setDogName] = useState('');
+  const [userName, setUserName] = useState('');
+  const [count, setCount] = useState(10);
+
+  // step 1 → 2 : 강아지 이름 저장 성공 시에만 내 이름 단계로
+  const handleDogNameNext = async () => {
+    const trimmed = dogName.trim();
+    if (!trimmed) return;
+    logButtonTap('onboarding_puppy_name_next');
+    try {
+      await renamePuppyMutation.mutateAsync(trimmed);
+      setStep(2);
+    } catch (error) {
+      console.log('온보딩 강아지 이름 설정 실패:', error);
+      Alert.alert('잠시 후 다시 시도해주세요', '이름 저장에 실패했어요.');
+    }
+  };
+
+  // step 2 → 3 : 내 이름 저장 성공 시에만 목표 단계로
+  const handleUserNameNext = async () => {
+    const trimmed = userName.trim();
+    if (!trimmed) return;
+    logButtonTap('onboarding_user_name_next');
+    try {
+      await renameUserMutation.mutateAsync(trimmed);
+      setStep(3);
+    } catch (error) {
+      console.log('온보딩 사용자 이름 설정 실패:', error);
+      Alert.alert('잠시 후 다시 시도해주세요', '이름 저장에 실패했어요.');
+    }
+  };
+
+  // step 3 : 목표 저장 성공 시에만 알림 권한 요청 → 홈 이동
+  const handleGoalNext = async () => {
+    logButtonTap('onboarding_goal_next');
+    try {
+      await createGoalMutation.mutateAsync({ goal: count, isNew: true });
+      await complete();
+    } catch (error) {
+      console.log('온보딩 목표 설정 실패:', error);
+      Alert.alert('잠시 후 다시 시도해주세요', '목표 저장에 실패했어요.');
+    }
+  };
+
+  const titleByStep: Record<Step, ReactNode> = {
+    1: (
+      <>
+        내 강아지에게{'\n'}
+        <Text style={styles.highlight}>이름</Text>을 지어주세요!
+      </>
+    ),
+    2: (
+      <>
+        <Text style={styles.highlight}>내 이름</Text>을 강아지에게{'\n'}
+        알려주세요!
+      </>
+    ),
+    3: (
+      <>
+        이번 달 <Text style={styles.highlight}>나의 목표</Text>로{'\n'}
+        정해봐요!
+      </>
+    ),
+  };
+
+  const subtitleByStep: Record<Step, string> = {
+    1: '이름을 지어주면 강아지와 더 친해질 수 있어요.',
+    2: '이름을 알려주면 강아지와 더 친해질 수 있어요.',
+    3: '목표는 언제든지 바꿀 수 있습니다.',
+  };
+
+  const bubbleByStep: Record<Step, string> = {
+    1: '주인님, 저에게 어울리는\n이름을 지어주세요!',
+    2: '주인님!\n앞으로는 어떻게 불러드릴까요?',
+    3: '이번 달에 지키고 싶은\n새로운 목표를 알려주세요!\n오늘부터 한 달 동안 지킬 거예요!',
+  };
+
+  return (
+    <OnboardingLayout
+      step={step}
+      breed={breed}
+      title={titleByStep[step]}
+      subtitle={subtitleByStep[step]}
+      bubbleText={bubbleByStep[step]}
+    >
+      {step === 1 ? (
+        <>
+          <TextInput
+            placeholder='이름을 입력해주세요.'
+            value={dogName}
+            onChangeText={setDogName}
+            returnKeyType='done'
+            onSubmitEditing={handleDogNameNext}
+          />
+          <PrimaryButton
+            title='다음으로'
+            onPress={handleDogNameNext}
+            disabled={!dogName.trim() || renamePuppyMutation.isPending}
+          />
+        </>
+      ) : step === 2 ? (
+        <>
+          <TextInput
+            placeholder='이름을 입력해주세요.'
+            value={userName}
+            onChangeText={setUserName}
+            returnKeyType='done'
+            onSubmitEditing={handleUserNameNext}
+          />
+          <PrimaryButton
+            title='다음으로'
+            onPress={handleUserNameNext}
+            disabled={!userName.trim() || renameUserMutation.isPending}
+          />
+        </>
+      ) : (
+        <>
+          <View style={styles.counterRow}>
+            <ControlButton
+              label='-'
+              onPress={() => setCount((n) => Math.max(1, n - 1))}
+            />
+            <ThemedView className='px-5 py-3 mx-1 bg-green-100 shadow-sm rounded-2xl'>
+              <ThemedText
+                style={{ color: '#21D08A', fontWeight: '600', fontSize: 16 }}
+                className='text-green-500'
+              >
+                {count}번
+              </ThemedText>
+            </ThemedView>
+            <ControlButton
+              label='+'
+              onPress={() => setCount((n) => Math.min(maxDaysInMonth, n + 1))}
+            />
+          </View>
+          <PrimaryButton
+            title='시작하기'
+            onPress={handleGoalNext}
+            disabled={createGoalMutation.isPending}
+          />
+        </>
+      )}
+    </OnboardingLayout>
+  );
+}
+
+const styles = StyleSheet.create({
+  highlight: {
+    color: '#0FD380',
+  },
+  counterRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -8,87 +8,124 @@ import { useCreateGoalMutation } from '@/hooks/mutations/useCreateGoalMutation';
 import { useRenamePuppyMutation } from '@/hooks/mutations/useRenamePuppyMutation';
 import { useRenameUserMutation } from '@/hooks/mutations/useRenameUserMutation';
 import { useCompleteOnboarding } from '@/hooks/onboarding/useCompleteOnboarding';
+import { usePuppyInfoQuery } from '@/hooks/queries/usePuppyInfoQuery';
 import { logButtonTap } from '@/utils/analytics';
 import { maxDaysInMonth } from '@/utils/dateUtils';
-import { useLocalSearchParams } from 'expo-router';
-import { useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Alert, StyleSheet, Text, View } from 'react-native';
 
-type Step = 1 | 2 | 3;
+type StepKey = 'puppyName' | 'userName' | 'goal';
+
+// 항상 이 순서로 노출하되, 아직 안 한 단계만 필터링해서 보여준다.
+const STEP_ORDER: StepKey[] = ['puppyName', 'userName', 'goal'];
 
 /**
- * 온보딩 화면 (한 화면, 3단계).
- * step 1: 강아지 이름 짓기
- * step 2: 내 이름 알려주기
- * step 3: 이번 달 목표(음주 허용 횟수) 설정 → (iOS 알림 권한 요청) → 홈
- * 배경 · 강아지 · 진행 점은 유지되고 타이틀 · 말풍선 · 하단 영역만 바뀐다.
+ * 온보딩 화면 (한 화면).
+ * 진입 시점의 완료 여부(isPuppyName / isMyName / isGoal)를 보고
+ * 아직 안 한 단계만 순서대로 보여준다. 진행 점도 그 개수만큼만 표시.
+ * 마지막 단계 완료 시 (iOS 알림 권한 요청 후) 홈으로 이동한다.
  */
 export default function Onboarding() {
-  const { breed } = useLocalSearchParams<{ breed?: string }>();
+  const { data: puppyInfo } = usePuppyInfoQuery();
   const createGoalMutation = useCreateGoalMutation();
   const renamePuppyMutation = useRenamePuppyMutation();
   const renameUserMutation = useRenameUserMutation();
   const { complete } = useCompleteOnboarding();
 
-  const [step, setStep] = useState<Step>(1);
+  // 진입 시점의 미완료 단계만 한 번 고정한다.
+  // (단계 완료 → puppyInfo 갱신으로 목록이 도중에 바뀌는 것을 방지)
+  const [steps, setSteps] = useState<StepKey[] | null>(null);
+  const [stepIndex, setStepIndex] = useState(0);
+  const initedRef = useRef(false);
+
   const [dogName, setDogName] = useState('');
   const [userName, setUserName] = useState('');
   const [count, setCount] = useState(10);
 
-  // step 1 → 2 : 강아지 이름 저장 성공 시에만 내 이름 단계로
-  const handleDogNameNext = async () => {
+  useEffect(() => {
+    if (!puppyInfo || initedRef.current) return;
+    initedRef.current = true;
+
+    const needed = STEP_ORDER.filter((key) => {
+      if (key === 'puppyName') return !puppyInfo.isPuppyName;
+      if (key === 'userName') return !puppyInfo.isMyName;
+      return !puppyInfo.isGoal;
+    });
+
+    if (needed.length === 0) {
+      // 이미 모두 완료된 상태로 진입한 경우 → 홈으로
+      complete();
+      return;
+    }
+    setSteps(needed);
+  }, [puppyInfo, complete]);
+
+  // 필요한 단계가 확정되기 전에는 렌더하지 않는다.
+  if (!steps || steps.length === 0) return null;
+
+  const currentKey = steps[stepIndex];
+  const isLast = stepIndex === steps.length - 1;
+  const nextTitle = isLast ? '시작하기' : '다음으로';
+
+  const goNext = async () => {
+    if (isLast) {
+      await complete();
+    } else {
+      setStepIndex((i) => i + 1);
+    }
+  };
+
+  const handlePuppyName = async () => {
     const trimmed = dogName.trim();
     if (!trimmed) return;
     logButtonTap('onboarding_puppy_name_next');
     try {
       await renamePuppyMutation.mutateAsync(trimmed);
-      setStep(2);
+      await goNext();
     } catch (error) {
       console.log('온보딩 강아지 이름 설정 실패:', error);
       Alert.alert('잠시 후 다시 시도해주세요', '이름 저장에 실패했어요.');
     }
   };
 
-  // step 2 → 3 : 내 이름 저장 성공 시에만 목표 단계로
-  const handleUserNameNext = async () => {
+  const handleUserName = async () => {
     const trimmed = userName.trim();
     if (!trimmed) return;
     logButtonTap('onboarding_user_name_next');
     try {
       await renameUserMutation.mutateAsync(trimmed);
-      setStep(3);
+      await goNext();
     } catch (error) {
       console.log('온보딩 사용자 이름 설정 실패:', error);
       Alert.alert('잠시 후 다시 시도해주세요', '이름 저장에 실패했어요.');
     }
   };
 
-  // step 3 : 목표 저장 성공 시에만 알림 권한 요청 → 홈 이동
-  const handleGoalNext = async () => {
+  const handleGoal = async () => {
     logButtonTap('onboarding_goal_next');
     try {
       await createGoalMutation.mutateAsync({ goal: count, isNew: true });
-      await complete();
+      await goNext();
     } catch (error) {
       console.log('온보딩 목표 설정 실패:', error);
       Alert.alert('잠시 후 다시 시도해주세요', '목표 저장에 실패했어요.');
     }
   };
 
-  const titleByStep: Record<Step, ReactNode> = {
-    1: (
+  const titleByKey: Record<StepKey, ReactNode> = {
+    puppyName: (
       <>
         내 강아지에게{'\n'}
         <Text style={styles.highlight}>이름</Text>을 지어주세요!
       </>
     ),
-    2: (
+    userName: (
       <>
         <Text style={styles.highlight}>내 이름</Text>을 강아지에게{'\n'}
         알려주세요!
       </>
     ),
-    3: (
+    goal: (
       <>
         이번 달 <Text style={styles.highlight}>나의 목표</Text>로{'\n'}
         정해봐요!
@@ -96,53 +133,54 @@ export default function Onboarding() {
     ),
   };
 
-  const subtitleByStep: Record<Step, string> = {
-    1: '이름을 지어주면 강아지와 더 친해질 수 있어요.',
-    2: '이름을 알려주면 강아지와 더 친해질 수 있어요.',
-    3: '목표는 언제든지 바꿀 수 있습니다.',
+  const subtitleByKey: Record<StepKey, string> = {
+    puppyName: '이름을 지어주면 강아지와 더 친해질 수 있어요.',
+    userName: '이름을 알려주면 강아지와 더 친해질 수 있어요.',
+    goal: '목표는 언제든지 바꿀 수 있습니다.',
   };
 
-  const bubbleByStep: Record<Step, string> = {
-    1: '주인님, 저에게 어울리는\n이름을 지어주세요!',
-    2: '주인님!\n앞으로는 어떻게 불러드릴까요?',
-    3: '이번 달에 지키고 싶은\n새로운 목표를 알려주세요!\n오늘부터 한 달 동안 지킬 거예요!',
+  const bubbleByKey: Record<StepKey, string> = {
+    puppyName: '주인님, 저에게 어울리는\n이름을 지어주세요!',
+    userName: '주인님!\n앞으로는 어떻게 불러드릴까요?',
+    goal: '이번 달에 지키고 싶은\n새로운 목표를 알려주세요!\n오늘부터 한 달 동안 지킬 거예요!',
   };
 
   return (
     <OnboardingLayout
-      step={step}
-      breed={breed}
-      title={titleByStep[step]}
-      subtitle={subtitleByStep[step]}
-      bubbleText={bubbleByStep[step]}
+      step={stepIndex + 1}
+      totalSteps={steps.length}
+      breed={puppyInfo?.puppyLevelName ?? ''}
+      title={titleByKey[currentKey]}
+      subtitle={subtitleByKey[currentKey]}
+      bubbleText={bubbleByKey[currentKey]}
     >
-      {step === 1 ? (
+      {currentKey === 'puppyName' ? (
         <>
           <TextInput
             placeholder='이름을 입력해주세요.'
             value={dogName}
             onChangeText={setDogName}
             returnKeyType='done'
-            onSubmitEditing={handleDogNameNext}
+            onSubmitEditing={handlePuppyName}
           />
           <PrimaryButton
-            title='다음으로'
-            onPress={handleDogNameNext}
+            title={nextTitle}
+            onPress={handlePuppyName}
             disabled={!dogName.trim() || renamePuppyMutation.isPending}
           />
         </>
-      ) : step === 2 ? (
+      ) : currentKey === 'userName' ? (
         <>
           <TextInput
             placeholder='이름을 입력해주세요.'
             value={userName}
             onChangeText={setUserName}
             returnKeyType='done'
-            onSubmitEditing={handleUserNameNext}
+            onSubmitEditing={handleUserName}
           />
           <PrimaryButton
-            title='다음으로'
-            onPress={handleUserNameNext}
+            title={nextTitle}
+            onPress={handleUserName}
             disabled={!userName.trim() || renameUserMutation.isPending}
           />
         </>
@@ -167,8 +205,8 @@ export default function Onboarding() {
             />
           </View>
           <PrimaryButton
-            title='시작하기'
-            onPress={handleGoalNext}
+            title={nextTitle}
+            onPress={handleGoal}
             disabled={createGoalMutation.isPending}
           />
         </>

--- a/app/test/proceeding.tsx
+++ b/app/test/proceeding.tsx
@@ -1,3 +1,4 @@
+import { PrimaryButton } from '@/components/common/buttons/PrimaryButton';
 import { QUERY_KEYS } from '@/hooks/queries/queryKeys';
 import { TestApi } from '@/services/testData';
 import { useQueryClient } from '@tanstack/react-query';
@@ -235,18 +236,11 @@ export default function TestProceeding() {
         </View>
       </View>
 
-      <TouchableOpacity
-        onPress={() => {
-          onPressNext();
-        }}
-        style={[
-          styles.bottomBtn,
-          selected[step] !== 0 && styles.bottomBtnActive,
-        ]}
+      <PrimaryButton
+        title='다음'
+        onPress={onPressNext}
         disabled={selected[step] === 0}
-      >
-        <Text className='font-medium text-white'>다음</Text>
-      </TouchableOpacity>
+      />
     </SafeAreaView>
   );
 }
@@ -307,23 +301,5 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '700',
     lineHeight: 22,
-  },
-  bottomBtn: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    width: '100%',
-    height: 60,
-    borderRadius: 10,
-    backgroundColor: '#C1C1C1',
-    color: '#F1F1F1',
-    textAlign: 'center',
-    fontSize: 16,
-    fontWeight: '500',
-    lineHeight: 24,
-    fontStyle: 'normal',
-  },
-  bottomBtnActive: {
-    backgroundColor: '#0FD380',
-    color: '#F2FFF4',
   },
 });

--- a/app/test/result.tsx
+++ b/app/test/result.tsx
@@ -41,11 +41,8 @@ const TestResult = () => {
   }, [cardSlideAnim]);
 
   const handleStart = () => {
-    // 온보딩(목표 → 이름)으로 진입. 알림 권한 요청은 온보딩 마지막 단계에서 실행된다.
-    router.replace({
-      pathname: '/onboarding',
-      params: { breed: puppyBreedKo },
-    });
+    // 온보딩으로 진입. 필요한 단계와 알림 권한 요청은 온보딩 화면에서 처리한다.
+    router.replace('/onboarding');
   };
 
   return (

--- a/app/test/result.tsx
+++ b/app/test/result.tsx
@@ -1,24 +1,15 @@
 import ResultBG from '@/assets/images/test/result-bg.svg';
+import { PrimaryButton } from '@/components/common/buttons/PrimaryButton';
 import { getPuppyGifSource } from '@/utils/dogMapper';
-import {
-  getIosNotificationPermissionStatus,
-  hasGrantedIosNotificationPermission,
-  requestIosNotificationPermission,
-} from '@/utils/notificationPermission';
 import { Image as ExpoImage } from 'expo-image';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useEffect, useRef } from 'react';
 import {
-  Alert,
   Animated,
-  AppState,
   Dimensions,
   Easing,
-  Linking,
-  Platform,
   StyleSheet,
   Text,
-  TouchableOpacity,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -27,7 +18,6 @@ const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 
 const TestResult = () => {
   const router = useRouter();
-  const shouldRecheckPermissionOnActive = useRef(false);
 
   const { result } = useLocalSearchParams<{
     result: string;
@@ -50,61 +40,12 @@ const TestResult = () => {
     }).start();
   }, [cardSlideAnim]);
 
-  useEffect(() => {
-    const subscription = AppState.addEventListener('change', (nextState) => {
-      if (nextState !== 'active' || !shouldRecheckPermissionOnActive.current) {
-        return;
-      }
-
-      shouldRecheckPermissionOnActive.current = false;
-
-      void (async () => {
-        const permission = await getIosNotificationPermissionStatus();
-        if (
-          permission &&
-          hasGrantedIosNotificationPermission(permission)
-        ) {
-          router.replace('/home');
-        }
-      })();
+  const handleStart = () => {
+    // 온보딩(목표 → 이름)으로 진입. 알림 권한 요청은 온보딩 마지막 단계에서 실행된다.
+    router.replace({
+      pathname: '/onboarding',
+      params: { breed: puppyBreedKo },
     });
-
-    return () => {
-      subscription.remove();
-    };
-  }, [router]);
-
-  const handleStart = async () => {
-    if (Platform.OS !== 'ios') {
-      router.replace('/home');
-      return;
-    }
-
-    const hasPermission = await requestIosNotificationPermission();
-
-    if (!hasPermission) {
-      Alert.alert(
-        '알림 권한이 꺼져 있어요',
-        'iOS에서는 한 번 거절하면 앱 설정에서 다시 켜야 해요.',
-        [
-          {
-            text: '나중에',
-            style: 'cancel',
-            onPress: () => router.replace('/home'),
-          },
-          {
-            text: '설정 열기',
-            onPress: () => {
-              shouldRecheckPermissionOnActive.current = true;
-              void Linking.openSettings();
-            },
-          },
-        ],
-      );
-      return;
-    }
-
-    router.replace('/home');
   };
 
   return (
@@ -146,9 +87,11 @@ const TestResult = () => {
         }}
         edges={['bottom']}
       >
-        <TouchableOpacity style={styles.bottomBtn} onPress={handleStart}>
-          <Text className='font-medium text-white'>시작하기</Text>
-        </TouchableOpacity>
+        <PrimaryButton
+          title='시작하기'
+          onPress={handleStart}
+          style={{ marginTop: (SCREEN_HEIGHT * 40) / 852 }}
+        />
       </SafeAreaView>
     </View>
   );
@@ -211,14 +154,5 @@ const styles = StyleSheet.create({
     lineHeight: 24,
     color: '#868686',
     textAlign: 'center',
-  },
-  bottomBtn: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginTop: (SCREEN_HEIGHT * 40) / 852,
-    width: '100%',
-    height: 60,
-    borderRadius: 10,
-    backgroundColor: '#0FD380',
   },
 });

--- a/app/test/start.tsx
+++ b/app/test/start.tsx
@@ -8,10 +8,10 @@ import {
   Image,
   StyleSheet,
   Text,
-  TouchableOpacity,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { PrimaryButton } from '@/components/common/buttons/PrimaryButton';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 
@@ -120,12 +120,10 @@ const TestStart = () => {
       </Animated.View>
 
       <SafeAreaView style={styles.buttonWrapper} edges={['bottom']}>
-        <TouchableOpacity
-          style={styles.button}
+        <PrimaryButton
+          title='시작하기'
           onPress={() => router.replace('/test/proceeding')}
-        >
-          <Text style={styles.buttonText}>시작하기</Text>
-        </TouchableOpacity>
+        />
       </SafeAreaView>
     </View>
   );
@@ -198,19 +196,5 @@ const styles = StyleSheet.create({
     right: 0,
     paddingHorizontal: 15,
     paddingVertical: 14,
-  },
-  button: {
-    width: '100%',
-    height: 60,
-    borderRadius: 10,
-    backgroundColor: '#0FD380',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  buttonText: {
-    fontSize: 16,
-    fontWeight: '500',
-    lineHeight: 24,
-    color: '#F2FFF4',
   },
 });

--- a/components/common/buttons/PrimaryButton.tsx
+++ b/components/common/buttons/PrimaryButton.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import {
+  StyleProp,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  ViewStyle,
+} from 'react-native';
+
+type PrimaryButtonProps = {
+  title: string;
+  onPress: () => void;
+  disabled?: boolean;
+  /** 화면별 여백 등 위치 조정용 (여백은 각 화면에서 주입한다) */
+  style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * 전체 화면 플로우(온보딩 · 강아지 입양 테스트)에서 공통으로 쓰는
+ * 하단 CTA 버튼. 높이 60 · radius 10 · 초록 배경.
+ * 위치/여백은 각 화면의 래퍼에서 담당하고, 필요하면 style로 덮어쓴다.
+ */
+export function PrimaryButton({
+  title,
+  onPress,
+  disabled = false,
+  style,
+}: PrimaryButtonProps) {
+  return (
+    <TouchableOpacity
+      style={[styles.button, disabled && styles.buttonDisabled, style]}
+      activeOpacity={0.85}
+      onPress={onPress}
+      disabled={disabled}
+    >
+      <Text style={[styles.buttonText, disabled && styles.buttonTextDisabled]}>
+        {title}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: '100%',
+    height: 60,
+    borderRadius: 10,
+    backgroundColor: '#0FD380',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonDisabled: {
+    backgroundColor: '#C1C1C1',
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: '500',
+    lineHeight: 24,
+    color: '#F2FFF4',
+  },
+  buttonTextDisabled: {
+    color: '#F1F1F1',
+  },
+});

--- a/components/page/home/SpeechBubble.tsx
+++ b/components/page/home/SpeechBubble.tsx
@@ -9,6 +9,8 @@ type SpeechBubbleProps = {
   onPress?: () => void;
   /** 지정 시 말풍선 최소 높이를 고정해, 줄 수가 달라도 높이를 일정하게 유지한다. */
   minHeight?: number;
+  /** 아래쪽 꼬리(화살표) 크기 배율. 기본 1. */
+  tailScale?: number;
 };
 
 export function SpeechBubble({
@@ -16,6 +18,7 @@ export function SpeechBubble({
   variant = 'puppy',
   onPress,
   minHeight,
+  tailScale = 1,
 }: SpeechBubbleProps) {
   const bgColor =
     variant === 'puppy'
@@ -52,9 +55,9 @@ export function SpeechBubble({
         style={{
           width: 0,
           height: 0,
-          borderLeftWidth: 6,
-          borderRightWidth: 6,
-          borderTopWidth: 8,
+          borderLeftWidth: 6 * tailScale,
+          borderRightWidth: 6 * tailScale,
+          borderTopWidth: 8 * tailScale,
           borderLeftColor: 'transparent',
           borderRightColor: 'transparent',
           borderTopColor: tailColor,

--- a/components/page/home/SpeechBubble.tsx
+++ b/components/page/home/SpeechBubble.tsx
@@ -7,12 +7,15 @@ type SpeechBubbleProps = {
   children: React.ReactNode;
   variant?: 'puppy' | 'user';
   onPress?: () => void;
+  /** 지정 시 말풍선 최소 높이를 고정해, 줄 수가 달라도 높이를 일정하게 유지한다. */
+  minHeight?: number;
 };
 
 export function SpeechBubble({
   children,
   variant = 'puppy',
   onPress,
+  minHeight,
 }: SpeechBubbleProps) {
   const bgColor =
     variant === 'puppy'
@@ -27,6 +30,7 @@ export function SpeechBubble({
   const Content = (
     <Animated.View
       className={`${bgColor}`}
+      style={minHeight ? { minHeight, justifyContent: 'center' } : undefined}
       entering={ZoomIn.duration(300).springify()}
     >
       <ThemedText className={textStyle}>{children}</ThemedText>

--- a/components/page/onboarding/OnboardingLayout.tsx
+++ b/components/page/onboarding/OnboardingLayout.tsx
@@ -1,0 +1,174 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import { EvolvingPuppy } from '@/components/page/home/EvolvingPuppy';
+import { SpeechBubble } from '@/components/page/home/SpeechBubble';
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
+  ImageBackground,
+  Keyboard,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
+import { OnboardingProgress } from './OnboardingProgress';
+
+// home보다 살짝 작은 강아지 (home: 288)
+const PUPPY_SIZE = 250;
+// 말풍선 최소 높이(3줄 기준). 단계별 멘트 줄 수가 달라도 높이를 일정하게 유지한다.
+const BUBBLE_MIN_HEIGHT = 120;
+
+type OnboardingLayoutProps = {
+  /** 진행 단계 (1부터 시작) */
+  step: number;
+  /** 상단 강조 타이틀 (초록 강조는 <Text style={{ color: '#0FD380' }}> 로 감싼다) */
+  title: React.ReactNode;
+  /** 타이틀 하단 보조 설명 */
+  subtitle: string;
+  /** 강아지 말풍선 내용 */
+  bubbleText: string;
+  /** 강아지 종(한글). 미지정 시 기본 비숑 */
+  breed?: string;
+  /** 하단 입력/버튼 영역. 키보드가 올라오면 함께 따라 올라온다. */
+  children: React.ReactNode;
+};
+
+/**
+ * 온보딩 공통 레이아웃.
+ * 배경(home과 동일) · 진행 점 · 타이틀 · 말풍선(home SpeechBubble) · 강아지(home EvolvingPuppy)를
+ * 항상 유지하고, 하단 영역(children)만 단계별로 바꿔 한 화면 안에서 자연스럽게 이어지도록 한다.
+ * 하단 영역은 home 이름 짓기처럼 키보드 높이에 맞춰 함께 올라온다.
+ */
+export function OnboardingLayout({
+  step,
+  title,
+  subtitle,
+  bubbleText,
+  breed = '',
+  children,
+}: OnboardingLayoutProps) {
+  const insets = useSafeAreaInsets();
+  const keyboardAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const showEvent =
+      Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent =
+      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+    const showSub = Keyboard.addListener(showEvent, (e) => {
+      Animated.timing(keyboardAnim, {
+        toValue: Math.max(0, e.endCoordinates.height - insets.bottom),
+        duration: e.duration ?? 250,
+        useNativeDriver: true,
+      }).start();
+    });
+    const hideSub = Keyboard.addListener(hideEvent, (e) => {
+      Animated.timing(keyboardAnim, {
+        toValue: 0,
+        duration: e.duration ?? 250,
+        useNativeDriver: true,
+      }).start();
+    });
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, [insets.bottom, keyboardAnim]);
+
+  return (
+    <ImageBackground
+      source={require('@/assets/images/home_background.png')}
+      style={styles.background}
+      resizeMode='cover'
+    >
+      <SafeAreaView style={styles.container}>
+        <View style={styles.progressWrapper}>
+          <OnboardingProgress step={step} total={3} />
+        </View>
+
+        <View style={styles.titleBlock}>
+          <Text style={styles.title}>{title}</Text>
+          <Text style={styles.subtitle}>{subtitle}</Text>
+        </View>
+
+        <View style={styles.middle}>
+          <View style={styles.bubbleWrapper}>
+            {/* step이 바뀌면 remount 되어 등장 애니메이션이 다시 재생된다. */}
+            <SpeechBubble key={step} minHeight={BUBBLE_MIN_HEIGHT}>
+              {bubbleText}
+            </SpeechBubble>
+          </View>
+          <EvolvingPuppy
+            breedName={breed}
+            level={1}
+            reaction='normal'
+            evolveEvent={null}
+            size={PUPPY_SIZE}
+          />
+        </View>
+
+        <Animated.View
+          style={[
+            styles.bottom,
+            { transform: [{ translateY: Animated.multiply(keyboardAnim, -1) }] },
+          ]}
+        >
+          {children}
+        </Animated.View>
+      </SafeAreaView>
+    </ImageBackground>
+  );
+}
+
+const styles = StyleSheet.create({
+  background: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 16,
+  },
+  progressWrapper: {
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  titleBlock: {
+    alignItems: 'center',
+    marginTop: 28,
+    gap: 10,
+  },
+  title: {
+    fontSize: 30,
+    fontWeight: '800',
+    lineHeight: 40,
+    color: '#000000',
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    lineHeight: 22,
+    color: '#777777',
+    textAlign: 'center',
+  },
+  middle: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+  },
+  bubbleWrapper: {
+    width: '100%',
+  },
+  bottom: {
+    paddingVertical: 14,
+    gap: 16,
+  },
+});

--- a/components/page/onboarding/OnboardingLayout.tsx
+++ b/components/page/onboarding/OnboardingLayout.tsx
@@ -175,7 +175,7 @@ const styles = StyleSheet.create({
   },
   bubbleWrapper: {
     width: '100%',
-    marginBottom: 0,
+    marginBottom: -40,
   },
   bottom: {
     paddingVertical: 14,

--- a/components/page/onboarding/OnboardingLayout.tsx
+++ b/components/page/onboarding/OnboardingLayout.tsx
@@ -25,6 +25,8 @@ const BUBBLE_MIN_HEIGHT = 120;
 type OnboardingLayoutProps = {
   /** 진행 단계 (1부터 시작) */
   step: number;
+  /** 전체 단계 수 (진행 점 개수) */
+  totalSteps?: number;
   /** 상단 강조 타이틀 (초록 강조는 <Text style={{ color: '#0FD380' }}> 로 감싼다) */
   title: React.ReactNode;
   /** 타이틀 하단 보조 설명 */
@@ -45,6 +47,7 @@ type OnboardingLayoutProps = {
  */
 export function OnboardingLayout({
   step,
+  totalSteps = 3,
   title,
   subtitle,
   bubbleText,
@@ -89,7 +92,7 @@ export function OnboardingLayout({
     >
       <SafeAreaView style={styles.container}>
         <View style={styles.progressWrapper}>
-          <OnboardingProgress step={step} total={3} />
+          <OnboardingProgress step={step} total={totalSteps} />
         </View>
 
         <View style={styles.titleBlock}>
@@ -100,7 +103,11 @@ export function OnboardingLayout({
         <View style={styles.middle}>
           <View style={styles.bubbleWrapper}>
             {/* step이 바뀌면 remount 되어 등장 애니메이션이 다시 재생된다. */}
-            <SpeechBubble key={step} minHeight={BUBBLE_MIN_HEIGHT}>
+            <SpeechBubble
+              key={step}
+              minHeight={BUBBLE_MIN_HEIGHT}
+              tailScale={2.4}
+            >
               {bubbleText}
             </SpeechBubble>
           </View>
@@ -116,7 +123,9 @@ export function OnboardingLayout({
         <Animated.View
           style={[
             styles.bottom,
-            { transform: [{ translateY: Animated.multiply(keyboardAnim, -1) }] },
+            {
+              transform: [{ translateY: Animated.multiply(keyboardAnim, -1) }],
+            },
           ]}
         >
           {children}
@@ -138,7 +147,7 @@ const styles = StyleSheet.create({
   },
   progressWrapper: {
     alignItems: 'center',
-    marginTop: 8,
+    marginTop: 26,
   },
   titleBlock: {
     alignItems: 'center',
@@ -166,6 +175,7 @@ const styles = StyleSheet.create({
   },
   bubbleWrapper: {
     width: '100%',
+    marginBottom: 0,
   },
   bottom: {
     paddingVertical: 14,

--- a/components/page/onboarding/OnboardingProgress.tsx
+++ b/components/page/onboarding/OnboardingProgress.tsx
@@ -1,5 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
+import Animated, {
+  interpolate,
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+const INACTIVE_COLOR = '#CBF1D3';
+const ACTIVE_COLOR = '#0FD380';
+const INACTIVE_WIDTH = 10;
+const ACTIVE_WIDTH = 22;
+const DURATION = 300;
 
 type OnboardingProgressProps = {
   /** 현재 단계 (1부터 시작) */
@@ -10,22 +23,39 @@ type OnboardingProgressProps = {
 
 /**
  * 온보딩 상단 진행 표시 점.
- * 현재 단계는 초록색 알약 형태, 나머지는 연한 초록 원으로 표시한다.
+ * 단계 전환 시 애니메이션.
  */
-export function OnboardingProgress({ step, total = 2 }: OnboardingProgressProps) {
+export function OnboardingProgress({
+  step,
+  total = 2,
+}: OnboardingProgressProps) {
   return (
     <View style={styles.container}>
-      {Array.from({ length: total }).map((_, index) => {
-        const isActive = index + 1 === step;
-        return (
-          <View
-            key={index}
-            style={[styles.dot, isActive ? styles.dotActive : styles.dotInactive]}
-          />
-        );
-      })}
+      {Array.from({ length: total }).map((_, index) => (
+        <Dot key={index} active={index + 1 === step} />
+      ))}
     </View>
   );
+}
+
+function Dot({ active }: { active: boolean }) {
+  // 0 = 비활성, 1 = 활성
+  const progress = useSharedValue(active ? 1 : 0);
+
+  useEffect(() => {
+    progress.value = withTiming(active ? 1 : 0, { duration: DURATION });
+  }, [active, progress]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    width: interpolate(progress.value, [0, 1], [INACTIVE_WIDTH, ACTIVE_WIDTH]),
+    backgroundColor: interpolateColor(
+      progress.value,
+      [0, 1],
+      [INACTIVE_COLOR, ACTIVE_COLOR],
+    ),
+  }));
+
+  return <Animated.View style={[styles.dot, animatedStyle]} />;
 }
 
 const styles = StyleSheet.create({
@@ -37,13 +67,5 @@ const styles = StyleSheet.create({
   dot: {
     height: 10,
     borderRadius: 100,
-  },
-  dotActive: {
-    width: 22,
-    backgroundColor: '#0FD380',
-  },
-  dotInactive: {
-    width: 10,
-    backgroundColor: '#CBF1D3',
   },
 });

--- a/components/page/onboarding/OnboardingProgress.tsx
+++ b/components/page/onboarding/OnboardingProgress.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+type OnboardingProgressProps = {
+  /** 현재 단계 (1부터 시작) */
+  step: number;
+  /** 전체 단계 수 */
+  total?: number;
+};
+
+/**
+ * 온보딩 상단 진행 표시 점.
+ * 현재 단계는 초록색 알약 형태, 나머지는 연한 초록 원으로 표시한다.
+ */
+export function OnboardingProgress({ step, total = 2 }: OnboardingProgressProps) {
+  return (
+    <View style={styles.container}>
+      {Array.from({ length: total }).map((_, index) => {
+        const isActive = index + 1 === step;
+        return (
+          <View
+            key={index}
+            style={[styles.dot, isActive ? styles.dotActive : styles.dotInactive]}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  dot: {
+    height: 10,
+    borderRadius: 100,
+  },
+  dotActive: {
+    width: 22,
+    backgroundColor: '#0FD380',
+  },
+  dotInactive: {
+    width: 10,
+    backgroundColor: '#CBF1D3',
+  },
+});

--- a/hooks/onboarding/useCompleteOnboarding.ts
+++ b/hooks/onboarding/useCompleteOnboarding.ts
@@ -1,0 +1,77 @@
+import {
+  getIosNotificationPermissionStatus,
+  hasGrantedIosNotificationPermission,
+  requestIosNotificationPermission,
+} from '@/utils/notificationPermission';
+import { useRouter } from 'expo-router';
+import { useEffect, useRef } from 'react';
+import { Alert, AppState, Linking, Platform } from 'react-native';
+
+/**
+ * 온보딩 마지막 단계 완료 처리.
+ * iOS 알림 권한을 요청하고(거절 시 설정 안내), 완료되면 홈으로 이동한다.
+ * 설정에서 권한을 켜고 앱으로 돌아오면 자동으로 홈 이동을 재시도한다.
+ *
+ * 기존 test/result 화면의 "시작하기" 로직을 그대로 옮긴 것으로,
+ * 온보딩(목표 → 이름) 흐름의 종료 지점에서 재사용한다.
+ */
+export function useCompleteOnboarding() {
+  const router = useRouter();
+  const shouldRecheckPermissionOnActive = useRef(false);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState !== 'active' || !shouldRecheckPermissionOnActive.current) {
+        return;
+      }
+
+      shouldRecheckPermissionOnActive.current = false;
+
+      void (async () => {
+        const permission = await getIosNotificationPermissionStatus();
+        if (permission && hasGrantedIosNotificationPermission(permission)) {
+          router.replace('/home');
+        }
+      })();
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [router]);
+
+  const complete = async () => {
+    if (Platform.OS !== 'ios') {
+      router.replace('/home');
+      return;
+    }
+
+    const hasPermission = await requestIosNotificationPermission();
+
+    if (!hasPermission) {
+      Alert.alert(
+        '알림 권한이 꺼져 있어요',
+        'iOS에서는 한 번 거절하면 앱 설정에서 다시 켜야 해요.',
+        [
+          {
+            text: '나중에',
+            style: 'cancel',
+            onPress: () => router.replace('/home'),
+          },
+          {
+            text: '설정 열기',
+            onPress: () => {
+              shouldRecheckPermissionOnActive.current = true;
+              void Linking.openSettings();
+            },
+          },
+        ],
+      );
+      return;
+    }
+
+    router.replace('/home');
+  };
+
+  return { complete };
+}


### PR DESCRIPTION
<!-- PR 제목은 이슈와 동일하게 작성하기 -->
<!-- [feat] 여러 이슈인 경우 공통 주제로 묶기 (#14, #15, #16) -->

## 작업 내용
- 강아지 이름 → 내 이름 → 목표 설정 3단계 온보딩 화면 추가 (한 화면 내 step 전환)
  - test/result '시작하기' → 온보딩 진입, 마지막 단계 완료 시 iOS 알림 권한 요청 후 홈 이동
  - 목표·이름 미설정 시 홈 대신 온보딩으로 리다이렉트
  - 각 단계는 API 성공 시에만 다음 단계로, 이름 미입력 시 버튼 비활성화
  - 진입 시점의 완료 여부(isPuppyName/isMyName/isGoal)로 필요한 단계만 표시
  - 진행 점(상단의 프로그레스 점)도 필요한 단계 수만큼만 표시 및 전환 애니메이션 추가
- 진행 점·말풍선(높이 고정)·강아지 GIF 등 home 공통 컴포넌트 재사용
- 전체 화면 CTA 버튼을 PrimaryButton으로 공용화 (온보딩·입양 테스트 화면)
- breed를 puppyInfo에서 직접 사용, 불필요한 route 파라미터 제거
- 말풍선 꼬리 크기 조정(온보딩 전용 tailScale) 및 위치 미세 조정

## 스크린샷 (UI 변경 시)
<img width="1311" height="620" alt="image" src="https://github.com/user-attachments/assets/69fb4572-2acc-462a-9b24-6a9bdfc00032" />


## 체크리스트
- [x] 동작 확인
- [x] Assignees 지정
- [x] Labels 지정
