### PR TITLE
[fix] iOS 푸시 알림 미수신

### DIFF
--- a/ios/puppymode.xcodeproj/project.pbxproj
+++ b/ios/puppymode.xcodeproj/project.pbxproj
@@ -402,7 +402,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = puppymode/puppymode.entitlements;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = AGQJU3FNWG;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -415,7 +415,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -443,7 +443,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = puppymode/puppymode.entitlements;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = AGQJU3FNWG;
 				INFOPLIST_FILE = puppymode/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -451,7 +451,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/puppymode/Info.plist
+++ b/ios/puppymode/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1.0</string>
+    <string>1.2.1</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -39,7 +39,9 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>4</string>
+    <string>15</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
     <key>UIBackgroundModes</key>
     <array>
       <string>remote-notification</string>

--- a/ios/puppymode/Info.plist
+++ b/ios/puppymode/Info.plist
@@ -40,6 +40,10 @@
     </array>
     <key>CFBundleVersion</key>
     <string>4</string>
+    <key>UIBackgroundModes</key>
+    <array>
+      <string>remote-notification</string>
+    </array>
     <key>KAKAO_APP_KEY</key>
     <string>c3e8f77f2c2654beb51541c4161ff1aa</string>
     <key>LSApplicationQueriesSchemes</key>

--- a/ios/puppymode/puppymode.entitlements
+++ b/ios/puppymode/puppymode.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>aps-environment</key>
+    <string>production</string>
     <key>com.apple.developer.applesignin</key>
     <array>
       <string>Default</string>


### PR DESCRIPTION
## 관련 이슈
closes #114 

## 작업 내용
- iOS 푸시 알림 미수신 수정 (entitlements `aps-environment` + Info.plist `UIBackgroundModes`)
- iOS 수출규정 암호화 면제 명시 (`ITSAppUsesNonExemptEncryption = false`)
- iOS 네이티브 버전 1.1.0 → 1.2.1 동기화 (build 15, App Store 출시본과 일치)
- ※ app.json/안드로이드(1.3.1)는 건드리지 않음 (iOS 별도 버전 트랙)

## 스크린샷 (UI 변경 시)
해당 없음 (네이티브 설정 변경만, UI 변화 없음)

## 체크리스트
- [x] 동작 확인 (App Store 1.2.1 배포 + 푸시 알림 테스트 완료)
- [x] Assignees 지정
- [x] Labels 지정